### PR TITLE
Split organization badge from labels in PDF list items

### DIFF
--- a/apps/web/components/pdf-list-item.tsx
+++ b/apps/web/components/pdf-list-item.tsx
@@ -117,6 +117,12 @@ export function PdfListItem({ pdf, handleDelete, style }: PdfListItemProps) {
           <div className="flex items-center w-full min-w-0">
             <div className="min-w-0 flex-1 pr-4 overflow-hidden flex flex-row justify-between">
               <div className="flex items-center overflow-hidden">
+                <DocumentMetadata
+                  metadata={effectiveMetadata}
+                  isListView={true}
+                  showLabels={false}
+                  className="mr-2"
+                />
                 <div className="font-medium text-sm mr-2 whitespace-nowrap">
                   {displayTitle}
                 </div>
@@ -125,6 +131,8 @@ export function PdfListItem({ pdf, handleDelete, style }: PdfListItemProps) {
                 <DocumentMetadata
                   metadata={effectiveMetadata}
                   isListView={true}
+                  showOrganization={false}
+                  className="ml-2"
                 />
                 {isMetadataLoading && !metadataError && (
                   <Loader2

--- a/apps/web/components/pdf-viewer/pdf-viewer-header.tsx
+++ b/apps/web/components/pdf-viewer/pdf-viewer-header.tsx
@@ -113,7 +113,10 @@ export const PdfViewerHeader = forwardRef<HTMLDivElement, PdfViewerHeaderProps>(
           </Button>
           <h2 className="font-medium flex items-center gap-2">
             {pdfMetadata?.descriptiveTitle || title}
-            <DocumentMetadata metadata={pdfMetadata || undefined} />
+            <DocumentMetadata
+              metadata={pdfMetadata || undefined}
+              className="ml-2"
+            />
           </h2>
         </div>
 


### PR DESCRIPTION
## Summary
- allow configuring label and organization display in `DocumentMetadata`
- show issuing organization to the left of the title in PDF list view
- keep labels to the right in list view
- adjust viewer header metadata usage

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*