### PR TITLE
Improve mobile layout

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -1,5 +1,6 @@
 import { PdfList } from "@/components/pdf-list";
 import { Sidebar } from "@/components/sidebar";
+import { MobileSidebar } from "@/components/mobile-sidebar";
 import { getAllPdfs, PDF } from "@/lib/db";
 import { auth } from "@clerk/nextjs/server";
 
@@ -25,12 +26,18 @@ export default async function HomePage() {
 
   return (
     <>
-      <Sidebar pdfs={pdfs} />
+      <div className="hidden md:block">
+        <Sidebar pdfs={pdfs} />
+      </div>
 
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex-1 flex flex-col overflow-hidden pb-12 md:pb-0">
         <main className="flex-1 overflow-auto">
           <PdfList pdfs={pdfs} />
         </main>
+      </div>
+
+      <div className="md:hidden">
+        <MobileSidebar pdfs={pdfs} />
       </div>
     </>
   );

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -183,3 +183,7 @@ mark {
 .react-pdf__Page__textContent {
   /* Add styles here if default text layer behavior causes issues with marks */
 }
+
+.hide-default-sheet-close > button.absolute.right-4.top-4 {
+  display: none !important;
+}

--- a/apps/web/components/mobile-sidebar.tsx
+++ b/apps/web/components/mobile-sidebar.tsx
@@ -16,16 +16,21 @@ export function MobileSidebar({ pdfs }: MobileSidebarProps) {
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <div className="fixed bottom-0 inset-x-0 z-40 flex items-center justify-center h-12 border-t bg-background md:hidden">
-        <SheetTrigger asChild>
-          <Button variant="ghost" size="icon">
-            <MenuIcon className="h-5 w-5" />
-            <span className="sr-only">Open sidebar</span>
-          </Button>
-        </SheetTrigger>
-      </div>
-      <SheetContent side="bottom" className="p-0 md:hidden">
-        <Sidebar pdfs={pdfs} />
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          className="fixed bottom-0 inset-x-0 z-40 flex h-12 w-full items-center justify-center border-t bg-background md:hidden"
+        >
+          <MenuIcon className="h-5 w-5" />
+          <span className="sr-only">Open sidebar</span>
+        </Button>
+      </SheetTrigger>
+
+      <SheetContent
+        side="bottom"
+        className="p-0 w-full max-w-none left-0 right-0 md:hidden hide-default-sheet-close"
+      >
+        <Sidebar pdfs={pdfs} className="w-full md:w-64" isSheetContext={true} />
       </SheetContent>
     </Sheet>
   );

--- a/apps/web/components/mobile-sidebar.tsx
+++ b/apps/web/components/mobile-sidebar.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { MenuIcon } from "lucide-react";
+import { Sidebar } from "@/components/sidebar";
+import { PDF } from "@/lib/db";
+
+interface MobileSidebarProps {
+  pdfs: PDF[];
+}
+
+export function MobileSidebar({ pdfs }: MobileSidebarProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <div className="fixed bottom-0 inset-x-0 z-40 flex items-center justify-center h-12 border-t bg-background md:hidden">
+        <SheetTrigger asChild>
+          <Button variant="ghost" size="icon">
+            <MenuIcon className="h-5 w-5" />
+            <span className="sr-only">Open sidebar</span>
+          </Button>
+        </SheetTrigger>
+      </div>
+      <SheetContent side="bottom" className="p-0 md:hidden">
+        <Sidebar pdfs={pdfs} />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/components/pdf-list-item.tsx
+++ b/apps/web/components/pdf-list-item.tsx
@@ -21,6 +21,7 @@ import { useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import { usePdfMetadata } from "@/hooks/use-pdf-metadata";
+import { useIsMobile } from "@/hooks/use-mobile";
 const TOOLTIP_WIDTH = 384; // max-w-sm = 24rem = 384px
 
 interface PdfListItemProps {
@@ -42,6 +43,7 @@ export function PdfListItem({ pdf, handleDelete, style }: PdfListItemProps) {
   const [isHovering, setIsHovering] = useState(false);
   const [tooltipPosition, setTooltipPosition] = useState<number | null>(null);
   const rowRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
 
   const effectiveMetadata = currentMetadata || {};
   const displayTitle =
@@ -114,27 +116,38 @@ export function PdfListItem({ pdf, handleDelete, style }: PdfListItemProps) {
         }}
       >
         <div className="flex-1 min-w-0">
-          <div className="flex items-center w-full min-w-0">
-            <div className="min-w-0 flex-1 pr-4 overflow-hidden flex flex-row justify-between">
-              <div className="flex items-center overflow-hidden">
-                <div className="font-medium text-sm mr-2 whitespace-nowrap">
-                  {displayTitle}
+          {isMobile ? (
+            <div className="flex flex-col overflow-hidden">
+              <div className="font-medium text-sm truncate">{displayTitle}</div>
+              {effectiveMetadata.issuingOrganization && (
+                <div className="text-xs text-muted-foreground truncate">
+                  {effectiveMetadata.issuingOrganization}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="flex items-center w-full min-w-0">
+              <div className="min-w-0 flex-1 pr-4 overflow-hidden flex flex-row justify-between">
+                <div className="flex items-center overflow-hidden">
+                  <div className="font-medium text-sm mr-2 whitespace-nowrap">
+                    {displayTitle}
+                  </div>
+                </div>
+                <div className="flex items-center justify-end min-w-0 overflow-hidden">
+                  <DocumentMetadata
+                    metadata={effectiveMetadata}
+                    isListView={true}
+                  />
+                  {isMetadataLoading && !metadataError && (
+                    <Loader2
+                      data-testid="metadata-loader"
+                      className="h-3 w-3 ml-1 animate-spin text-muted-foreground inline-block"
+                    />
+                  )}
                 </div>
               </div>
-              <div className="flex items-center justify-end min-w-0 overflow-hidden">
-                <DocumentMetadata
-                  metadata={effectiveMetadata}
-                  isListView={true}
-                />
-                {isMetadataLoading && !metadataError && (
-                  <Loader2
-                    data-testid="metadata-loader"
-                    className="h-3 w-3 ml-1 animate-spin text-muted-foreground inline-block"
-                  />
-                )}
-              </div>
             </div>
-          </div>
+          )}
         </div>
 
         <div className="w-12 flex justify-center">

--- a/apps/web/components/pdf-list.tsx
+++ b/apps/web/components/pdf-list.tsx
@@ -95,7 +95,7 @@ export function PdfList({ pdfs }: PdfListProps) {
     );
   };
 
-  const ITEM_HEIGHT = 40;
+  const ITEM_HEIGHT = 48;
 
   if (pdfs.length === 0) {
     return (
@@ -154,8 +154,7 @@ export function PdfList({ pdfs }: PdfListProps) {
   return (
     <div
       data-testid="pdf-list"
-      className="w-full h-full flex flex-col"
-      style={{ height: "calc(100vh - 10px)" }}
+      className="w-full h-full flex flex-col h-[calc(100vh-58px)] md:h-[calc(100vh-10px)]"
     >
       <div className="flex-1 flex flex-col border-b overflow-hidden">
         <div className="flex items-center p-3 font-medium text-sm bg-background z-10 border-b">

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -10,20 +10,39 @@ import {
 } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import { PDF } from "@/lib/db";
+import { cn } from "@/lib/utils";
+import { SheetClose } from "@/components/ui/sheet";
+import { X } from "lucide-react";
 
 interface SidebarProps {
   pdfs: PDF[];
+  className?: string;
+  isSheetContext?: boolean;
 }
 
-export function Sidebar({ pdfs }: SidebarProps) {
+export function Sidebar({ pdfs, className, isSheetContext }: SidebarProps) {
   return (
-    <div className="w-64 border-r flex flex-col h-full bg-stone-50">
+    <div className={cn("border-r flex flex-col h-full bg-stone-50", className)}>
       <div className="px-4 h-[45px] border-b flex justify-between items-center w-full">
         <SignedIn>
-          <div className="grow-1">
+          <div className="flex-grow">
             <OrganizationSwitcher />
           </div>
-          <FileUpload className="grow-0"></FileUpload>
+          <div className="flex items-center gap-2">
+            <FileUpload />
+            {isSheetContext && (
+              <SheetClose asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="md:hidden bg-muted hover:bg-muted/90 rounded-lg h-6 w-6"
+                >
+                  <X className="h-3 w-3 stroke-[3]" />
+                  <span className="sr-only">Close sidebar</span>
+                </Button>
+              </SheetClose>
+            )}
+          </div>
         </SignedIn>
       </div>
 


### PR DESCRIPTION
## Summary
- add mobile bottom sidebar with sheet
- adjust home page layout to use mobile sidebar
- adapt PDF list items for small screens and enlarge item height
- account for bottom bar height in list height

## Testing
- `pnpm --filter web test` *(fails: vitest not found)*