### PR TITLE
Enable slide-in PDF viewer

### DIFF
--- a/apps/web/components/pdf-list-item.tsx
+++ b/apps/web/components/pdf-list-item.tsx
@@ -28,9 +28,10 @@ interface PdfListItemProps {
   pdf: PDF;
   handleDelete: (id: number) => void;
   style?: React.CSSProperties; // For react-window
+  onOpen?: (pdf: PDF) => void;
 }
 
-export function PdfListItem({ pdf, handleDelete, style }: PdfListItemProps) {
+export function PdfListItem({ pdf, handleDelete, style, onOpen }: PdfListItemProps) {
   const router = useRouter();
   const {
     metadata: currentMetadata,
@@ -103,30 +104,30 @@ export function PdfListItem({ pdf, handleDelete, style }: PdfListItemProps) {
     );
   };
 
-  return (
-    <Link
-      data-testid="pdf-list-item"
-      href={`/pdfs/${pdf.id}`}
-      className="block w-full"
+  const row = (
+    <div
+      ref={rowRef}
+      className="flex items-center px-3 py-1 border-b-slate-100 border-b hover:bg-muted/50 transition-colors relative"
+      style={style}
+      data-id={pdf.id}
+      onMouseMove={handleMouseMove}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => {
+        setIsHovering(false);
+        setMouseX(null);
+        setRowBottom(null);
+        setTooltipPosition(null);
+      }}
+      onClick={() => {
+        if (onOpen) {
+          onOpen(pdf);
+        }
+      }}
     >
-      <div
-        ref={rowRef}
-        className="flex items-center px-3 py-1 border-b-slate-100 border-b hover:bg-muted/50 transition-colors relative"
-        style={style}
-        data-id={pdf.id}
-        onMouseMove={handleMouseMove}
-        onMouseEnter={() => setIsHovering(true)}
-        onMouseLeave={() => {
-          setIsHovering(false);
-          setMouseX(null);
-          setRowBottom(null);
-          setTooltipPosition(null);
-        }}
-      >
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center w-full min-w-0">
-            <div className="min-w-0 flex-1 pr-4 overflow-hidden flex flex-row justify-between">
-              <div className="flex items-center overflow-hidden">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center w-full min-w-0">
+          <div className="min-w-0 flex-1 pr-4 overflow-hidden flex flex-row justify-between">
+            <div className="flex items-center overflow-hidden">
                 <div className="font-medium text-sm mr-2 whitespace-nowrap">
                   {displayTitle}
                 </div>
@@ -182,6 +183,19 @@ export function PdfListItem({ pdf, handleDelete, style }: PdfListItemProps) {
 
         {renderTooltip()}
       </div>
+  );
+
+  if (onOpen) {
+    return (
+      <div data-testid="pdf-list-item" className="block w-full">
+        {row}
+      </div>
+    );
+  }
+
+  return (
+    <Link data-testid="pdf-list-item" href={`/pdfs/${pdf.id}`} className="block w-full">
+      {row}
     </Link>
   );
 }

--- a/apps/web/components/pdf-list.tsx
+++ b/apps/web/components/pdf-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useOptimistic } from "react";
+import { useMemo, useOptimistic, useState } from "react";
 import { useOrganization } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import { FileUpload } from "@/components/file-upload";
@@ -18,6 +18,7 @@ import { PDF } from "@/lib/db";
 import { FixedSizeList as List } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { PdfListItem } from "./pdf-list-item";
+import { PdfPreviewPanel } from "./pdf-preview-panel";
 
 interface PdfListProps {
   pdfs: PDF[];
@@ -36,6 +37,9 @@ export function PdfList({ pdfs }: PdfListProps) {
     (state: PDF[], pdfIdToRemove: number) =>
       state.filter((pdf) => pdf.id !== pdfIdToRemove)
   );
+
+  const [selectedPdf, setSelectedPdf] = useState<PDF | null>(null);
+  const [viewerOpen, setViewerOpen] = useState(false);
 
   const handleDelete = async (id: number) => {
     removeOptimisticPdf(id);
@@ -91,6 +95,10 @@ export function PdfList({ pdfs }: PdfListProps) {
         pdf={pdf}
         handleDelete={handleDelete}
         style={style}
+        onOpen={(p) => {
+          setSelectedPdf(p);
+          setViewerOpen(true);
+        }}
       />
     );
   };
@@ -152,12 +160,13 @@ export function PdfList({ pdfs }: PdfListProps) {
   }
 
   return (
-    <div
-      data-testid="pdf-list"
-      className="w-full h-full flex flex-col"
-      style={{ height: "calc(100vh - 10px)" }}
-    >
-      <div className="flex-1 flex flex-col border-b overflow-hidden">
+    <>
+      <div
+        data-testid="pdf-list"
+        className="w-full h-full flex flex-col"
+        style={{ height: "calc(100vh - 10px)" }}
+      >
+        <div className="flex-1 flex flex-col border-b overflow-hidden">
         <div className="flex items-center p-3 font-medium text-sm bg-background z-10 border-b">
           <div className="flex-1">
             <div className="flex items-center gap-1">Document</div>
@@ -185,6 +194,14 @@ export function PdfList({ pdfs }: PdfListProps) {
           </AutoSizer>
         </div>
       </div>
-    </div>
+      </div>
+      {selectedPdf && (
+        <PdfPreviewPanel
+          pdf={selectedPdf}
+          open={viewerOpen}
+          onClose={() => setViewerOpen(false)}
+        />
+      )}
+    </>
   );
 }

--- a/apps/web/components/pdf-preview-panel.tsx
+++ b/apps/web/components/pdf-preview-panel.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { PDF } from "@/lib/db";
+import { PdfViewer } from "@/components/pdf-viewer";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PdfPreviewPanelProps {
+  pdf: PDF;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function PdfPreviewPanel({ pdf, open, onClose }: PdfPreviewPanelProps) {
+  return (
+    <div
+      className={cn(
+        "fixed inset-y-0 right-0 z-40 w-full max-w-3xl bg-background border-l shadow-xl transform transition-transform duration-300",
+        open ? "translate-x-0" : "translate-x-full"
+      )}
+    >
+      <button
+        aria-label="Close"
+        className="absolute top-2 right-2 rounded-md p-2 hover:bg-muted"
+        onClick={onClose}
+      >
+        <X className="h-4 w-4" />
+      </button>
+      <PdfViewer pdf={pdf} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `PdfPreviewPanel` component for sliding PDF viewer panel
- update PDF list item to support opening viewer without navigation
- manage preview state in PDF list component

## Testing
- `pnpm --filter web tsc` *(fails: cannot find module 'clsx' and many others)*